### PR TITLE
Fetch students with grade and section

### DIFF
--- a/app/Http/Controllers/API/StudentController.php
+++ b/app/Http/Controllers/API/StudentController.php
@@ -25,6 +25,11 @@ class StudentController extends Controller
         return $students;
     }
     
+    public function show($id) 
+    {    
+        return Student::with('enrolledClasses')->where('id', $id)->get();
+    }
+    
     public function subjects()
     {
         $user = Auth::guard('web:student')->user();

--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -42,6 +42,14 @@ class Student extends User
                     ->orWhere('status', AcademicYear::STATUS_ENROLLMENT);
             });
     }
+    
+    public function enrolledClasses()
+    {
+        return $this->hasMany(Enrollee::class)
+            ->where('status', Enrollee::STATUS_ENROLLED)
+            ->with('section')
+            ->with('gradeLevel');
+    }
 
     protected static function booted(): void
     {

--- a/routes/api.php
+++ b/routes/api.php
@@ -50,6 +50,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/users/{user}/thread', [MessageThreadController::class, 'findThread']);
 
     Route::get('/students', [StudentController::class, 'index']);
+    Route::get('/students/{id}', [StudentController::class, 'show']);
     Route::get('/student/subjects', [StudentController::class, 'subjects']);
     Route::post('/enrollment', [StudentRegistrationController::class, 'enroll']);
     Route::get('/enrollment', [EnrolleeController::class, 'index']);


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a new API endpoint `/students/{id}` to fetch individual student records. This includes their enrolled classes, section, and grade level details.
- New Feature: Enhanced the `Student` model with a method `enrolledClasses()` to retrieve the list of classes a student is enrolled in, along with related data.
  
These updates provide more detailed information about students, improving data accessibility for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->